### PR TITLE
panic = "abort"

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["staticlib"]
 
 [profile.release]
 lto = true
+panic = "abort"
 
 [dependencies]
 savvy = "0"


### PR DESCRIPTION
Since the savvy framework doesn't rely on panic, let's give up recovering from panic and reduce the binary size.