### PR TITLE
Support cross-compiling for macOS

### DIFF
--- a/configure
+++ b/configure
@@ -1,3 +1,41 @@
+#!/bin/sh
+
+usage()
+{
+  cat - <<EOF
+Options:
+  --help   show help
+  --build  specify target
+EOF
+  exit 0
+}
+
+args()
+{
+  while [ 0 -lt $# ]; do
+    OPT="$1"
+    shift 1
+    case "${OPT}" in
+      --help|-h)
+        usage
+        ;;
+      --build=*)
+        case $(echo "${OPT}" | cut -c 9-) in
+          aarch64-apple-darwin*)
+            TARGET="aarch64-apple-darwin"
+            TARGET_ARG="--target ${TARGET}"
+            ;;
+        esac
+        ;;
+      # ignore unknown options silently
+    esac
+  done
+}
+
+# define $TARGET and $TARGET_ARG if provided via --build arg
+# c.f. https://www.gnu.org/prep/standards/html_node/Configuration.html
+args $*
+
 # The envvar used in libR-sys crate
 LIBRSYS_R_VERSION=$("${R_HOME}/bin/Rscript" "./tools/print_r_version.R")
 
@@ -37,6 +75,8 @@ fi
 sed \
   -e "s|@BEFORE_CARGO_BUILD@|${BEFORE_CARGO_BUILD}|" \
   -e "s|@AFTER_CARGO_BUILD@|${AFTER_CARGO_BUILD}|" \
+  -e "s|@TARGET@|${TARGET}|" \
+  -e "s|@TARGET_ARG@|${TARGET_ARG}|" \
   src/Makevars.in > src/Makevars
 
 # Uncomment this to debug

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,8 +1,11 @@
+TARGET = @TARGET@
+TARGET_ARG = @TARGET_ARG@
+
 # TODO
 VENDORING = yes
 OFFLINE_OPTION = --offline
 
-LIBDIR = ./rust/target/release
+LIBDIR = ./rust/target/$(TARGET)/release
 PKG_LIBS = -L$(LIBDIR) -lstring2path
 STATLIB = $(LIBDIR)/libstring2path.a
 
@@ -19,7 +22,7 @@ $(STATLIB):
 	    cp ./cargo_vendor_config.toml ./rust/.cargo/config.toml; \
 	fi
 
-	@BEFORE_CARGO_BUILD@ cd ./rust && cargo build --jobs 1 --lib --release $(OFFLINE_OPTION)
+	@BEFORE_CARGO_BUILD@ cd ./rust && cargo build --jobs 1 $(TARGET_ARG) --lib --release $(OFFLINE_OPTION)
 	@AFTER_CARGO_BUILD@
 
 C_clean:

--- a/src/Makevars.win.in
+++ b/src/Makevars.win.in
@@ -1,4 +1,5 @@
 TARGET = x86_64-pc-windows-gnu
+TARGET_ARG = --target $(TARGET)
 
 # Rtools42 doesn't have the linker in the location that cargo expects, so we
 # need to overwrite it via configuration.
@@ -27,7 +28,7 @@ $(STATLIB):
 	    cp ./cargo_vendor_config.toml ./rust/.cargo/config.toml; \
 	fi
 
-	@BEFORE_CARGO_BUILD@ cd ./rust && cargo build --jobs 1 --target $(TARGET) --lib --release $(OFFLINE_OPTION)
+	@BEFORE_CARGO_BUILD@ cd ./rust && cargo build --jobs 1 $(TARGET_ARG) --lib --release $(OFFLINE_OPTION)
 	@AFTER_CARGO_BUILD@
 
 C_clean:


### PR DESCRIPTION
`--build` arg is provided (c.f. [doc about the convention](https://www.gnu.org/prep/standards/html_node/Configuration.html)) for macOS build.

`R CMD INSTALL ${{inputs.sourcepkg}} --library=armcross --no-test-load --configure-args="--build=aarch64-apple-darwin20 --host=x86_64-apple-darwin20"`

https://github.com/r-universe/workflows/blob/9355082e241f26496479c1808caed5e15a3d9861/.github/workflows/build.yml#L262-L267
https://github.com/r-universe-org/build-and-check/blob/v1/macos-cross/action.yml
