### PR TITLE
Support COLRv1 emoji font

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # string2path (development version)
 
+* Partially support COLRv1 emoji fonts.
+  * COLRv1 emoji font is a color emoji, but not all color emoji is COLRv1
+    format. For example, Noto Color Emoji has several variants, and it seems
+    the primary one is CBDT/CBLC format.
+  * Additional information are currently just discarded.
+    * The color information can be useful. Currently, it's not obvious what
+      format (e.g. an attribute of the result data.frame?) is the best to
+      return it to users.
+    * The clip and layer composition information are just discarded. While
+      this can be useful, it's not very easy to use these information in R.
+
 # string2path 0.1.8
 
 * This is a maintenance release to comply with the CRAN repository policy.

--- a/src/rust/src/builder.rs
+++ b/src/rust/src/builder.rs
@@ -1,20 +1,26 @@
-use lyon::math::point;
+use lyon::{geom::euclid::UnknownUnit, math::point, path::traits::PathBuilder};
 use ttf_parser::{colr::Painter, Face};
 
 pub struct LyonPathBuilder {
     // It's not very elegant to store the glyph ID (not the `glyphId` ttf-parser
     // uses, but the glyph count) and path ID in attributes, but it seems the
     // attribute is the only thing we can pass to tessellators.
-    pub builder: lyon::path::path::BuilderWithAttributes,
+    pub builder: lyon::path::builder::Transformed<
+        lyon::path::path::BuilderWithAttributes,
+        lyon::math::Transform,
+    >,
 
     pub cur_glyph_id: u32,
     pub cur_path_id: u32,
 
-    // multiply by this to scale the position into the range of [0, 1].
-    pub scale_factor: f32,
+    // This transformation is of COLR format.
+    base_transform: lyon::geom::euclid::Transform2D<f32, UnknownUnit, UnknownUnit>,
 
-    pub offset_x: f32,
-    pub offset_y: f32,
+    // multiply by this to scale the position into the range of [0, 1].
+    scale_factor: f32,
+
+    offset_x: f32,
+    offset_y: f32,
 
     pub tolerance: f32,
 
@@ -25,27 +31,80 @@ pub struct LyonPathBuilder {
 impl LyonPathBuilder {
     pub fn new(tolerance: f32, line_width: f32) -> Self {
         Self {
-            builder: lyon::path::Path::builder_with_attributes(2),
+            builder: lyon::path::Path::builder_with_attributes(2)
+                .transformed(lyon::geom::euclid::Transform2D::identity()),
             cur_glyph_id: 0,
             cur_path_id: 0,
+            base_transform: lyon::geom::euclid::Transform2D::identity(),
+            scale_factor: 1.,
             offset_x: 0.,
             offset_y: 0.,
             tolerance,
             line_width,
-            scale_factor: 1.,
         }
     }
 
     // adds offsets to x and y
-    pub(crate) fn point(&self, x: f32, y: f32) -> lyon::math::Point {
-        point(
-            (x + self.offset_x) * self.scale_factor,
-            (y + self.offset_y) * self.scale_factor,
-        )
+    pub fn point(&self, x: f32, y: f32) -> lyon::math::Point {
+        point(x, y)
     }
 
-    pub(crate) fn ids(&self) -> [f32; 2] {
+    pub fn ids(&self) -> [f32; 2] {
         [self.cur_glyph_id as _, self.cur_path_id as _]
+    }
+
+    pub fn update_transform(&mut self) {
+        let transform = self
+            .base_transform
+            .then_translate(lyon::geom::euclid::Vector2D::new(
+                self.offset_x,
+                self.offset_y,
+            ))
+            .then_scale(self.scale_factor, self.scale_factor);
+        self.builder.set_transform(transform);
+    }
+
+    pub fn set_scale_factor(&mut self, scale_factor: f32) {
+        self.scale_factor = scale_factor;
+        self.update_transform();
+    }
+
+    pub fn add_offset_x(&mut self, x: f32) {
+        self.offset_x += x;
+        self.update_transform();
+    }
+
+    pub fn add_offset_y(&mut self, y: f32) {
+        self.offset_y += y;
+        self.update_transform();
+    }
+
+    pub fn sub_offset_x(&mut self, x: f32) {
+        self.offset_x -= x;
+        self.update_transform();
+    }
+
+    pub fn sub_offset_y(&mut self, y: f32) {
+        self.offset_y -= y;
+        self.update_transform();
+    }
+
+    pub fn reset_offset_x(&mut self) {
+        self.offset_x = 0.0;
+        self.update_transform();
+    }
+
+    pub fn reset_offset_y(&mut self) {
+        self.offset_y = 0.0;
+        self.update_transform();
+    }
+
+    pub fn set_transform(
+        &mut self,
+        transform: lyon::geom::euclid::Transform2D<f32, UnknownUnit, UnknownUnit>,
+    ) {
+        self.base_transform = transform;
+        self.update_transform();
     }
 }
 
@@ -77,13 +136,13 @@ impl ttf_parser::OutlineBuilder for LyonPathBuilder {
     }
 }
 
-pub(crate) struct LyonPathBuilderForPaint<'a> {
+pub struct LyonPathBuilderForPaint<'a> {
     builder: &'a mut LyonPathBuilder,
     face: &'a Face<'a>,
 }
 
 impl<'a> LyonPathBuilderForPaint<'a> {
-    pub(crate) fn new(builder: &'a mut LyonPathBuilder, face: &'a Face<'a>) -> Self {
+    pub fn new(builder: &'a mut LyonPathBuilder, face: &'a Face<'a>) -> Self {
         Self { builder, face }
     }
 }
@@ -93,7 +152,7 @@ impl<'a> Painter<'a> for LyonPathBuilderForPaint<'a> {
         self.face.outline_glyph(glyph_id, self.builder);
     }
 
-    fn paint(&mut self, paint: ttf_parser::colr::Paint<'a>) {
+    fn paint(&mut self, _paint: ttf_parser::colr::Paint<'a>) {
         // ignore
     }
 
@@ -101,7 +160,7 @@ impl<'a> Painter<'a> for LyonPathBuilderForPaint<'a> {
         // ignore
     }
 
-    fn push_clip_box(&mut self, clipbox: ttf_parser::colr::ClipBox) {
+    fn push_clip_box(&mut self, _clipbox: ttf_parser::colr::ClipBox) {
         // ignore
     }
 
@@ -109,7 +168,7 @@ impl<'a> Painter<'a> for LyonPathBuilderForPaint<'a> {
         // ignore
     }
 
-    fn push_layer(&mut self, mode: ttf_parser::colr::CompositeMode) {
+    fn push_layer(&mut self, _mode: ttf_parser::colr::CompositeMode) {
         // ignore
     }
 
@@ -118,10 +177,20 @@ impl<'a> Painter<'a> for LyonPathBuilderForPaint<'a> {
     }
 
     fn push_transform(&mut self, transform: ttf_parser::Transform) {
-        // ignore
+        let transform = lyon::geom::euclid::Transform2D::new(
+            // cf. https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-12-and-13-painttransform-paintvartransform
+            transform.a, // xx
+            transform.b, // yx
+            transform.c, // xy
+            transform.d, // yy
+            transform.e, // dx
+            transform.f, // dy
+        );
+        self.builder.set_transform(transform);
     }
 
     fn pop_transform(&mut self) {
-        // ignore
+        self.builder
+            .set_transform(lyon::geom::euclid::Transform2D::identity());
     }
 }

--- a/src/rust/src/builder.rs
+++ b/src/rust/src/builder.rs
@@ -1,4 +1,5 @@
 use lyon::math::point;
+use ttf_parser::{colr::Painter, Face};
 
 pub struct LyonPathBuilder {
     // It's not very elegant to store the glyph ID (not the `glyphId` ttf-parser
@@ -73,5 +74,54 @@ impl ttf_parser::OutlineBuilder for LyonPathBuilder {
     fn close(&mut self) {
         self.builder.end(true);
         self.cur_path_id += 1;
+    }
+}
+
+pub(crate) struct LyonPathBuilderForPaint<'a> {
+    builder: &'a mut LyonPathBuilder,
+    face: &'a Face<'a>,
+}
+
+impl<'a> LyonPathBuilderForPaint<'a> {
+    pub(crate) fn new(builder: &'a mut LyonPathBuilder, face: &'a Face<'a>) -> Self {
+        Self { builder, face }
+    }
+}
+
+impl<'a> Painter<'a> for LyonPathBuilderForPaint<'a> {
+    fn outline_glyph(&mut self, glyph_id: ttf_parser::GlyphId) {
+        self.face.outline_glyph(glyph_id, self.builder);
+    }
+
+    fn paint(&mut self, paint: ttf_parser::colr::Paint<'a>) {
+        // ignore
+    }
+
+    fn push_clip(&mut self) {
+        // ignore
+    }
+
+    fn push_clip_box(&mut self, clipbox: ttf_parser::colr::ClipBox) {
+        // ignore
+    }
+
+    fn pop_clip(&mut self) {
+        // ignore
+    }
+
+    fn push_layer(&mut self, mode: ttf_parser::colr::CompositeMode) {
+        // ignore
+    }
+
+    fn pop_layer(&mut self) {
+        // ignore
+    }
+
+    fn push_transform(&mut self, transform: ttf_parser::Transform) {
+        // ignore
+    }
+
+    fn pop_transform(&mut self) {
+        // ignore
     }
 }

--- a/src/rust/src/font.rs
+++ b/src/rust/src/font.rs
@@ -139,7 +139,7 @@ impl LyonPathBuilder {
         let facetables = font.tables();
 
         let height = font.height() as f32;
-        self.scale_factor = 1. / height;
+        self.set_scale_factor(1. / height);
         let line_height = height + font.line_gap() as f32;
 
         let mut prev_glyph: Option<GlyphId> = None;
@@ -148,8 +148,8 @@ impl LyonPathBuilder {
             if c.is_control() {
                 // If the character is a line break, move to the next line
                 if c == '\n' {
-                    self.offset_y -= line_height;
-                    self.offset_x = 0.;
+                    self.sub_offset_y(line_height);
+                    self.reset_offset_x();
                 }
                 prev_glyph = None;
                 continue;
@@ -158,7 +158,7 @@ impl LyonPathBuilder {
             let cur_glyph = font.glyph_index(c).unwrap_or(GlyphId(0));
 
             if let Some(prev_glyph) = prev_glyph {
-                self.offset_x += find_kerning(facetables, prev_glyph, cur_glyph) as f32;
+                self.add_offset_x(find_kerning(facetables, prev_glyph, cur_glyph) as f32);
             }
 
             if font.is_color_glyph(cur_glyph) {
@@ -173,7 +173,7 @@ impl LyonPathBuilder {
             }
 
             if let Some(ha) = font.glyph_hor_advance(cur_glyph) {
-                self.offset_x += ha as f32;
+                self.add_offset_x(ha as f32);
             }
 
             prev_glyph = Some(cur_glyph);

--- a/src/rust/src/into_fill_stroke.rs
+++ b/src/rust/src/into_fill_stroke.rs
@@ -1,6 +1,7 @@
 use crate::{builder::LyonPathBuilder, result::PathTibble};
 
 use lyon::tessellation::*;
+use path::traits::Build;
 
 #[derive(Copy, Clone, Debug)]
 struct Vertex {

--- a/src/rust/src/into_path.rs
+++ b/src/rust/src/into_path.rs
@@ -1,3 +1,5 @@
+use lyon::path::traits::Build;
+
 use crate::builder::LyonPathBuilder;
 use crate::result::PathTibble;
 


### PR DESCRIPTION
Close #64 

**Caveats**

This support is not complete. 

* The color information is not included. While it's probably not so difficult, it's not very obvious what format is the best.
* The clip information and layer information are just discarded. While these might be useful, it's probably not easy to plot them.

```r
library(ggplot2)

devtools::load_all("~/repo/string2path/")

# Note: it seems Noto Color Emoji has many variants. Only that of COLRv1 format
# is supported, so this might not work on installed font of Noto Color Emoji.
ttf <- "~/Downloads/NotoColorEmoji-Regular.ttf"

d <-
  string2fill("🌶", ttf, tolerance = 1e-4) |>
  tibble::rowid_to_column()

ggplot(d) +
  geom_polygon(aes(x, y, group = path_id, fill = factor(path_id)), colour = "green", alpha = 0.7) +
  coord_equal() +
  theme_minimal() +
  theme(legend.position = "none") +
  scale_fill_viridis_d(option = "F")
```

![image](https://github.com/user-attachments/assets/bad2708d-3089-4f8a-9032-d93e663e3071)
