### PR TITLE
Fix color

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,9 +5,6 @@
     format. For example, Noto Color Emoji has several variants, and it seems
     the primary one is CBDT/CBLC format.
   * Additional information are currently just discarded.
-    * The color information can be useful. Currently, it's not obvious what
-      format (e.g. an attribute of the result data.frame?) is the best to
-      return it to users.
     * The clip and layer composition information are just discarded. While
       this can be useful, it's not very easy to use these information in R.
 

--- a/src/rust/src/builder.rs
+++ b/src/rust/src/builder.rs
@@ -162,9 +162,11 @@ impl LyonPathBuilder {
         self.update_transform();
     }
 
-    fn pop_layer(&mut self) {
-        self.cur_layer -= 1;
-    }
+    // is this needed?
+    //
+    // fn pop_layer(&mut self) {
+    //     self.cur_layer -= 1;
+    // }
 }
 
 impl ttf_parser::OutlineBuilder for LyonPathBuilder {

--- a/src/rust/src/into_fill_stroke.rs
+++ b/src/rust/src/into_fill_stroke.rs
@@ -8,6 +8,7 @@ struct Vertex {
     position: lyon::math::Point,
     glyph_id: u32,
     path_id: u32,
+    color: [u8; 4],
 }
 
 // This can have some members so that it can be used in new_vertex(), but I
@@ -22,6 +23,7 @@ impl FillVertexConstructor<Vertex> for VertexCtor {
             position: pos,
             glyph_id: attr[0] as _,
             path_id: attr[1] as _,
+            color: attr[2].to_ne_bytes(),
         }
     }
 }
@@ -34,6 +36,7 @@ impl StrokeVertexConstructor<Vertex> for VertexCtor {
             position: pos,
             glyph_id: attr[0] as _,
             path_id: attr[1] as _,
+            color: attr[2].to_ne_bytes(),
         }
     }
 }
@@ -92,6 +95,7 @@ fn extract_vertex_buffer(geometry: VertexBuffers<Vertex, usize>) -> PathTibble {
     let mut glyph_id: Vec<i32> = Vec::new();
     let mut path_id: Vec<i32> = Vec::new();
     let mut triangle_id: Vec<i32> = Vec::new();
+    let mut color: Vec<String> = Vec::new();
 
     for (n, &i) in geometry.indices.iter().enumerate() {
         if let Some(v) = geometry.vertices.get(i) {
@@ -100,6 +104,9 @@ fn extract_vertex_buffer(geometry: VertexBuffers<Vertex, usize>) -> PathTibble {
             glyph_id.push(v.glyph_id as _);
             path_id.push(v.path_id as _);
             triangle_id.push(n as i32 / 3);
+
+            let [r, g, b, a] = v.color;
+            color.push(format!("#{r:02x}{g:02x}{b:02x}{a:02x}"));
         }
     }
 
@@ -109,5 +116,6 @@ fn extract_vertex_buffer(geometry: VertexBuffers<Vertex, usize>) -> PathTibble {
         glyph_id,
         path_id,
         triangle_id: Some(triangle_id),
+        color: Some(color),
     }
 }

--- a/src/rust/src/into_fill_stroke.rs
+++ b/src/rust/src/into_fill_stroke.rs
@@ -1,7 +1,6 @@
 use crate::{builder::LyonPathBuilder, result::PathTibble};
 
 use lyon::tessellation::*;
-use path::traits::Build;
 
 #[derive(Copy, Clone, Debug)]
 struct Vertex {
@@ -43,79 +42,91 @@ impl StrokeVertexConstructor<Vertex> for VertexCtor {
 
 impl LyonPathBuilder {
     /// Convert the outline paths into fill as triangles.
-    pub fn into_fill(self) -> PathTibble {
-        let path = self.builder.build();
+    pub fn into_fill(mut self) -> PathTibble {
+        let paths = self.build();
+        let mut result = PathTibble {
+            x: Vec::new(),
+            y: Vec::new(),
+            glyph_id: Vec::new(),
+            path_id: Vec::new(),
+            triangle_id: Some(Vec::new()),
+            color: Some(Vec::new()),
+        };
 
         // Will contain the result of the tessellation.
-        let mut geometry: VertexBuffers<Vertex, usize> = VertexBuffers::new();
         let mut tessellator = FillTessellator::new();
         let options = FillOptions::tolerance(self.tolerance);
 
-        {
-            // Compute the tessellation.
-            tessellator
-                .tessellate_path(
-                    &path,
-                    &options,
-                    &mut BuffersBuilder::new(&mut geometry, VertexCtor {}),
-                )
-                .unwrap();
+        for path in paths {
+            let mut geometry: VertexBuffers<Vertex, usize> = VertexBuffers::new();
+            {
+                // Compute the tessellation.
+                tessellator
+                    .tessellate_path(
+                        &path,
+                        &options,
+                        &mut BuffersBuilder::new(&mut geometry, VertexCtor {}),
+                    )
+                    .unwrap();
+            }
+            extract_vertex_buffer(geometry, &mut result);
         }
-
-        extract_vertex_buffer(geometry)
+        result
     }
 
     /// Convert the outline paths into stroke with a specified line width as triangles.
-    pub fn into_stroke(self) -> PathTibble {
-        let path = self.builder.build();
+    pub fn into_stroke(mut self) -> PathTibble {
+        let paths = self.build();
+        let mut result = PathTibble {
+            x: Vec::new(),
+            y: Vec::new(),
+            glyph_id: Vec::new(),
+            path_id: Vec::new(),
+            triangle_id: Some(Vec::new()),
+            color: Some(Vec::new()),
+        };
 
         // Will contain the result of the tessellation.
-        let mut geometry: VertexBuffers<Vertex, usize> = VertexBuffers::new();
         let mut tessellator = StrokeTessellator::new();
         let options = StrokeOptions::tolerance(self.tolerance).with_line_width(self.line_width);
+        for path in paths {
+            let mut geometry: VertexBuffers<Vertex, usize> = VertexBuffers::new();
+            {
+                // Compute the tessellation.
+                tessellator
+                    .tessellate_path(
+                        &path,
+                        &options,
+                        &mut BuffersBuilder::new(&mut geometry, VertexCtor {}),
+                    )
+                    .unwrap();
+            }
 
-        {
-            // Compute the tessellation.
-            tessellator
-                .tessellate_path(
-                    &path,
-                    &options,
-                    &mut BuffersBuilder::new(&mut geometry, VertexCtor {}),
-                )
-                .unwrap();
+            extract_vertex_buffer(geometry, &mut result);
         }
-
-        extract_vertex_buffer(geometry)
+        result
     }
 }
 
-fn extract_vertex_buffer(geometry: VertexBuffers<Vertex, usize>) -> PathTibble {
-    let mut x: Vec<f64> = Vec::new();
-    let mut y: Vec<f64> = Vec::new();
-    let mut glyph_id: Vec<i32> = Vec::new();
-    let mut path_id: Vec<i32> = Vec::new();
-    let mut triangle_id: Vec<i32> = Vec::new();
-    let mut color: Vec<String> = Vec::new();
-
+fn extract_vertex_buffer(geometry: VertexBuffers<Vertex, usize>, dst: &mut PathTibble) {
+    let offset = dst.triangle_id.as_ref().map_or(0, |v| match v.last() {
+        Some(last_triangle_id) => last_triangle_id + 1,
+        None => 0,
+    });
     for (n, &i) in geometry.indices.iter().enumerate() {
         if let Some(v) = geometry.vertices.get(i) {
-            x.push(v.position.x as _);
-            y.push(v.position.y as _);
-            glyph_id.push(v.glyph_id as _);
-            path_id.push(v.path_id as _);
-            triangle_id.push(n as i32 / 3);
+            dst.x.push(v.position.x as _);
+            dst.y.push(v.position.y as _);
+            dst.glyph_id.push(v.glyph_id as _);
+            dst.path_id.push(v.path_id as _);
+            if let Some(triangle_id) = &mut dst.triangle_id {
+                triangle_id.push(n as i32 / 3 + offset);
+            }
 
-            let [r, g, b, a] = v.color;
-            color.push(format!("#{r:02x}{g:02x}{b:02x}{a:02x}"));
+            if let Some(color) = &mut dst.color {
+                let [r, g, b, a] = v.color;
+                color.push(format!("#{r:02x}{g:02x}{b:02x}{a:02x}"));
+            }
         }
-    }
-
-    PathTibble {
-        x,
-        y,
-        glyph_id,
-        path_id,
-        triangle_id: Some(triangle_id),
-        color: Some(color),
     }
 }

--- a/src/rust/src/into_path.rs
+++ b/src/rust/src/into_path.rs
@@ -79,6 +79,7 @@ impl LyonPathBuilder {
             glyph_id,
             path_id,
             triangle_id: None,
+            color: None, // TODO
         }
     }
 }

--- a/src/rust/src/into_path.rs
+++ b/src/rust/src/into_path.rs
@@ -1,3 +1,5 @@
+use ttf_parser::RgbaColor;
+
 use crate::builder::LyonPathBuilder;
 use crate::result::PathTibble;
 
@@ -10,8 +12,22 @@ impl LyonPathBuilder {
         let mut y: Vec<f64> = Vec::new();
         let mut glyph_id: Vec<i32> = Vec::new();
         let mut path_id: Vec<i32> = Vec::new();
+        let mut color: Option<Vec<String>> = if self.layer_color.is_empty() {
+            None
+        } else {
+            Some(Vec::new())
+        };
 
-        for path in paths {
+        for (path, paint_color) in paths {
+            let paint_color = match paint_color {
+                Some(RgbaColor {
+                    red,
+                    green,
+                    blue,
+                    alpha,
+                }) => format!("#{red:02x}{green:02x}{blue:02x}{alpha:02x}",),
+                None => "#00000000".to_string(),
+            };
             for p in path.iter_with_attributes() {
                 match p {
                     lyon::path::Event::Begin { at } => {
@@ -19,12 +35,18 @@ impl LyonPathBuilder {
                         path_id.push(at.1[1] as _);
                         x.push(at.0.x as _);
                         y.push(at.0.y as _);
+                        if let Some(v) = color.as_mut() {
+                            v.push(paint_color.clone())
+                        }
                     }
                     lyon::path::Event::Line { from, to } => {
                         glyph_id.push(from.1[0] as _);
                         path_id.push(from.1[1] as _);
                         x.push(to.0.x as _);
                         y.push(to.0.y as _);
+                        if let Some(v) = color.as_mut() {
+                            v.push(paint_color.clone())
+                        }
                     }
                     lyon::path::Event::Quadratic { from, ctrl, to } => {
                         let seg = lyon::geom::QuadraticBezierSegment {
@@ -38,6 +60,9 @@ impl LyonPathBuilder {
                             path_id.push(from.1[1] as _);
                             x.push(p.x as _);
                             y.push(p.y as _);
+                            if let Some(v) = color.as_mut() {
+                                v.push(paint_color.clone())
+                            }
                         }
                     }
                     lyon::path::Event::Cubic {
@@ -58,6 +83,9 @@ impl LyonPathBuilder {
                             path_id.push(from.1[1] as _);
                             x.push(p.x as _);
                             y.push(p.y as _);
+                            if let Some(v) = color.as_mut() {
+                                v.push(paint_color.clone())
+                            }
                         }
                     }
                     // glyph can be "open path," even when `close` is true. In that case, `first` should point to the begin point.
@@ -67,6 +95,9 @@ impl LyonPathBuilder {
                             path_id.push(first.1[1] as _);
                             x.push(first.0.x as _);
                             y.push(first.0.y as _);
+                            if let Some(v) = color.as_mut() {
+                                v.push(paint_color.clone())
+                            }
                         }
                     }
                 }
@@ -79,7 +110,7 @@ impl LyonPathBuilder {
             glyph_id,
             path_id,
             triangle_id: None,
-            color: None, // TODO
+            color,
         }
     }
 }

--- a/src/rust/src/into_path.rs
+++ b/src/rust/src/into_path.rs
@@ -1,73 +1,73 @@
-use lyon::path::traits::Build;
-
 use crate::builder::LyonPathBuilder;
 use crate::result::PathTibble;
 
 impl LyonPathBuilder {
     /// Extract the outline path to PathTibble.
-    pub fn into_path(self) -> PathTibble {
-        let path = self.builder.build();
+    pub fn into_path(mut self) -> PathTibble {
+        let paths = self.build();
 
         let mut x: Vec<f64> = Vec::new();
         let mut y: Vec<f64> = Vec::new();
         let mut glyph_id: Vec<i32> = Vec::new();
         let mut path_id: Vec<i32> = Vec::new();
 
-        for p in path.iter_with_attributes() {
-            match p {
-                lyon::path::Event::Begin { at } => {
-                    glyph_id.push(at.1[0] as _);
-                    path_id.push(at.1[1] as _);
-                    x.push(at.0.x as _);
-                    y.push(at.0.y as _);
-                }
-                lyon::path::Event::Line { from, to } => {
-                    glyph_id.push(from.1[0] as _);
-                    path_id.push(from.1[1] as _);
-                    x.push(to.0.x as _);
-                    y.push(to.0.y as _);
-                }
-                lyon::path::Event::Quadratic { from, ctrl, to } => {
-                    let seg = lyon::geom::QuadraticBezierSegment {
-                        from: from.0,
-                        ctrl,
-                        to: to.0,
-                    };
-                    // skip the first point as it's already added
-                    for p in seg.flattened(self.tolerance).skip(1) {
+        for path in paths {
+            for p in path.iter_with_attributes() {
+                match p {
+                    lyon::path::Event::Begin { at } => {
+                        glyph_id.push(at.1[0] as _);
+                        path_id.push(at.1[1] as _);
+                        x.push(at.0.x as _);
+                        y.push(at.0.y as _);
+                    }
+                    lyon::path::Event::Line { from, to } => {
                         glyph_id.push(from.1[0] as _);
                         path_id.push(from.1[1] as _);
-                        x.push(p.x as _);
-                        y.push(p.y as _);
+                        x.push(to.0.x as _);
+                        y.push(to.0.y as _);
                     }
-                }
-                lyon::path::Event::Cubic {
-                    from,
-                    ctrl1,
-                    ctrl2,
-                    to,
-                } => {
-                    let seg = lyon::geom::CubicBezierSegment {
-                        from: from.0,
+                    lyon::path::Event::Quadratic { from, ctrl, to } => {
+                        let seg = lyon::geom::QuadraticBezierSegment {
+                            from: from.0,
+                            ctrl,
+                            to: to.0,
+                        };
+                        // skip the first point as it's already added
+                        for p in seg.flattened(self.tolerance).skip(1) {
+                            glyph_id.push(from.1[0] as _);
+                            path_id.push(from.1[1] as _);
+                            x.push(p.x as _);
+                            y.push(p.y as _);
+                        }
+                    }
+                    lyon::path::Event::Cubic {
+                        from,
                         ctrl1,
                         ctrl2,
-                        to: to.0,
-                    };
-                    // skip the first point as it's already added
-                    for p in seg.flattened(self.tolerance).skip(1) {
-                        glyph_id.push(from.1[0] as _);
-                        path_id.push(from.1[1] as _);
-                        x.push(p.x as _);
-                        y.push(p.y as _);
+                        to,
+                    } => {
+                        let seg = lyon::geom::CubicBezierSegment {
+                            from: from.0,
+                            ctrl1,
+                            ctrl2,
+                            to: to.0,
+                        };
+                        // skip the first point as it's already added
+                        for p in seg.flattened(self.tolerance).skip(1) {
+                            glyph_id.push(from.1[0] as _);
+                            path_id.push(from.1[1] as _);
+                            x.push(p.x as _);
+                            y.push(p.y as _);
+                        }
                     }
-                }
-                // glyph can be "open path," even when `close` is true. In that case, `first` should point to the begin point.
-                lyon::path::Event::End { last, first, close } => {
-                    if close && last != first {
-                        glyph_id.push(first.1[0] as _);
-                        path_id.push(first.1[1] as _);
-                        x.push(first.0.x as _);
-                        y.push(first.0.y as _);
+                    // glyph can be "open path," even when `close` is true. In that case, `first` should point to the begin point.
+                    lyon::path::Event::End { last, first, close } => {
+                        if close && last != first {
+                            glyph_id.push(first.1[0] as _);
+                            path_id.push(first.1[1] as _);
+                            x.push(first.0.x as _);
+                            y.push(first.0.y as _);
+                        }
                     }
                 }
             }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -110,7 +110,13 @@ fn string2stroke_file(
     tolerance: f64,
     line_width: f64,
 ) -> savvy::Result<savvy::Sexp> {
-    string2any_file(text, font_file, tolerance, line_width, ConversionType::Stroke)
+    string2any_file(
+        text,
+        font_file,
+        tolerance,
+        line_width,
+        ConversionType::Stroke,
+    )
 }
 
 #[savvy]

--- a/src/rust/src/result.rs
+++ b/src/rust/src/result.rs
@@ -12,13 +12,21 @@ pub struct PathTibble {
     pub path_id: Vec<i32>,
     // IDs to distinguish the triangles. This field is `None` for `ConversionType::Path`.
     pub triangle_id: Option<Vec<i32>>,
+    // Color of color emoji font.
+    pub color: Option<Vec<String>>,
 }
 
 impl TryFrom<PathTibble> for savvy::Sexp {
     type Error = savvy::Error;
 
     fn try_from(value: PathTibble) -> savvy::Result<Self> {
-        let len = if value.triangle_id.is_none() { 4 } else { 5 };
+        let mut len = 4;
+        if value.triangle_id.is_some() {
+            len += 1
+        };
+        if value.color.is_some() {
+            len += 1
+        };
         let mut out = savvy::OwnedListSexp::new(len, true)?;
 
         out.set_name_and_value(0, "x", <OwnedRealSexp>::try_from(value.x.as_slice())?)?;
@@ -34,12 +42,18 @@ impl TryFrom<PathTibble> for savvy::Sexp {
             <OwnedIntegerSexp>::try_from(value.path_id.as_slice())?,
         )?;
 
+        let mut idx = 3;
         if let Some(triangle_id) = value.triangle_id {
+            idx += 1;
             out.set_name_and_value(
-                4,
+                idx,
                 "triangle_id",
                 <OwnedIntegerSexp>::try_from(triangle_id.as_slice())?,
             )?;
+        }
+        if let Some(color) = value.color {
+            idx += 1;
+            out.set_name_and_value(idx, "color", <OwnedStringSexp>::try_from(color.as_slice())?)?;
         }
 
         out.into()


### PR DESCRIPTION
A follow up to support COLRv1.

``` r
# Note: it seems Noto Color Emoji has many variants. Only that of COLRv1 format
# is supported, so this might not work on installed font of Noto Color Emoji.
ttf <- "~/Downloads/NotoColorEmoji-Regular.ttf"

d <- string2path("🌶", ttf)
ggplot(d) +
  geom_path(aes(x, y, group = path_id, color = color)) +
  coord_equal() +
  theme_minimal() +
  scale_color_identity()

d <- string2stroke("🌶", ttf)
ggplot(d) +
  geom_polygon(aes(x, y, group = triangle_id, fill = color)) +
  coord_equal() +
  theme_minimal() +
  scale_fill_identity()

d <- string2fill("🌶", ttf)
ggplot(d) +
  geom_polygon(aes(x, y, group = triangle_id, fill = color)) +
  coord_equal() +
  theme_minimal() +
  scale_fill_identity()

```

![plot](https://github.com/user-attachments/assets/b56af863-3871-48e6-aae4-403cf4575a91)
![plot](https://github.com/user-attachments/assets/861d0d3e-78d4-4666-9580-5787fb3bb46b)
![plot](https://github.com/user-attachments/assets/055d8902-e19f-40a3-9aab-1b3917f877e7)
