### PR TITLE
Fix a regression related to whitespace

### DIFF
--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -50,6 +50,23 @@
       2 0     0.800        1           0
       3 0.800 0.800        1           0
 
+# handle white spaces
+
+    Code
+      string2path("A A", "./font/test.ttf")
+    Output
+      # A tibble: 8 x 4
+            x     y glyph_id path_id
+        <dbl> <dbl>    <int>   <int>
+      1 0     0            1       1
+      2 0.800 0.800        1       1
+      3 0     0.800        1       1
+      4 0     0            1       1
+      5 1.60  0            3       2
+      6 2.40  0.800        3       2
+      7 1.60  0.800        3       2
+      8 1.60  0            3       2
+
 # the data extracted from installed font are as expected
 
     Code

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -4,6 +4,11 @@ test_that("the data extracted from font file are as expected", {
   expect_snapshot(string2fill("A", "./font/test.ttf"))
 })
 
+test_that("handle white spaces", {
+  expect_snapshot(string2path("A A", "./font/test.ttf"))
+})
+
+
 test_that("the data extracted from installed font are as expected", {
   skip_if_not(isTRUE("Arial" %in% dump_fontdb()$family))
 


### PR DESCRIPTION
Fix #74 

Previously, if `font.outline_glyph()` returns an error, it's just ignored. The problem is that the current implementation coverts it to an error. This pull request fixes it by not outlining when it's a whitespace. The same failure might happen in some more cases, but I can't come up with actual cases. Just be optimistic for now.