### PR TITLE
ci: Remove case with R-devel on Windows

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release',  rust: 'stable-msvc'}
-          - {os: windows-latest, r: 'devel',    rust: 'stable-msvc'}
           - {os: macOS-latest,   r: 'release',  rust: 'stable'     }
           - {os: ubuntu-latest,  r: 'release',  rust: 'stable'     }
           - {os: ubuntu-latest,  r: 'devel',    rust: 'stable'     }


### PR DESCRIPTION
As it seems Rtools version won't be bumped between R 4.4 and R 4.5, this case is probably redundant. Removing for now.