### PR TITLE
Use FillRule::NonZero

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # string2path (development version)
 
+* Fix a regression about fill rule (#131).
+
 # string2path 0.2.0
 
 * Partially support COLRv1 emoji fonts.

--- a/src/rust/src/into_fill_stroke.rs
+++ b/src/rust/src/into_fill_stroke.rs
@@ -42,7 +42,7 @@ impl LyonPathBuilderForStrokeAndFill {
 
         // Will contain the result of the tessellation.
         let mut tessellator = FillTessellator::new();
-        let options = FillOptions::tolerance(self.tolerance);
+        let options = FillOptions::tolerance(self.tolerance).with_fill_rule(FillRule::NonZero);
 
         let mut cur_path_id: u32 = 0;
         for (path, color) in paths {


### PR DESCRIPTION
Fix #131 

``` r
library(string2path)
library(ggplot2)

d <- string2fill("4", "Noto Sans JP", font_weight = "bold")
ggplot(d, aes(x, y, group = triangle_id)) +
  geom_polygon()
```

![](https://i.imgur.com/KavSfWx.png)<!-- -->

<sup>Created on 2025-02-10 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
