### PR TITLE
Clean up intermediate static lib

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -50,3 +50,4 @@ jobs:
 
       - name: debug
         run: cat ./check/*.Rcheck/00install.out
+        if: ${{ always() }}

--- a/configure
+++ b/configure
@@ -36,7 +36,9 @@ elif [ "${NOT_CRAN}" != "true" ]; then
   AFTER_CARGO_BUILD="${AFTER_CARGO_BUILD}"'rm -Rf $(PWD)/.cargo $(LIBDIR)/build'
   VENDORING="yes"
   OFFLINE_OPTION="--offline"
+  CLEANUP="C_cleanup"
 else
+  CLEANUP="cleanup"
   echo "*** Detected NOT_CRAN=true, do not override CARGO_HOME"
 fi
 
@@ -46,6 +48,7 @@ sed \
   -e "s|@VENDORING@|${VENDORING}|" \
   -e "s|@OFFLINE_OPTION@|${OFFLINE_OPTION}|" \
   -e "s|@TARGET@|${TARGET}|" \
+  -e "s|@CLEANUP@|${CLEANUP}|" \
   src/Makevars.in > src/Makevars
 
 # Uncomment this to debug

--- a/configure.win
+++ b/configure.win
@@ -27,7 +27,9 @@ if [ "${NOT_CRAN}" != "true" ]; then
   AFTER_CARGO_BUILD="${AFTER_CARGO_BUILD}"'rm -Rf $(PWD)/.cargo $(LIBDIR)/build'
   VENDORING="yes"
   OFFLINE_OPTION="--offline"
+  CLEANUP="C_cleanup"
 else
+  CLEANUP="cleanup"
   echo "*** Detected NOT_CRAN=true, do not override CARGO_HOME"
 fi
 
@@ -36,6 +38,7 @@ sed \
   -e "s|@AFTER_CARGO_BUILD@|${AFTER_CARGO_BUILD}|" \
   -e "s|@VENDORING@|${VENDORING}|" \
   -e "s|@OFFLINE_OPTION@|${OFFLINE_OPTION}|" \
+  -e "s|@CLEANUP@|${CLEANUP}|" \
   src/Makevars.win.in > src/Makevars.win
 
 # Uncomment this to debug

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -7,7 +7,7 @@ LIBDIR = ./rust/target/$(TARGET)/release
 PKG_LIBS = -L$(LIBDIR) -lstring2path
 STATLIB = $(LIBDIR)/libstring2path.a
 
-all: C_clean
+all: $(SHLIB) @CLEANUP@
 
 $(SHLIB): $(STATLIB)
 
@@ -30,10 +30,10 @@ $(STATLIB):
 	fi
 	@AFTER_CARGO_BUILD@
 
-C_clean:
-	rm -Rf $(SHLIB) $(OBJECTS) ./rust/.cargo $(STATLIB)
+C_cleanup:
+	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo
 
-clean:
+cleanup:
 	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
 
-.PHONY: all C_clean clean
+.PHONY: all C_cleanup cleanup

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -31,9 +31,9 @@ $(STATLIB):
 	@AFTER_CARGO_BUILD@
 
 C_cleanup:
-	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo
+	rm -Rf $(STATLIB) ./rust/.cargo
 
 cleanup:
-	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
+	rm -Rf $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
 
 .PHONY: all C_cleanup cleanup

--- a/src/Makevars.win.in
+++ b/src/Makevars.win.in
@@ -11,7 +11,7 @@ LIBDIR = ./rust/target/$(TARGET)/release
 PKG_LIBS = -L$(LIBDIR) -lstring2path -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
 STATLIB = $(LIBDIR)/libstring2path.a
 
-all: C_clean
+all: $(SHLIB) @CLEANUP@
 
 $(SHLIB): $(STATLIB)
 
@@ -29,10 +29,10 @@ $(STATLIB):
 	@BEFORE_CARGO_BUILD@ cd ./rust && cargo build --jobs 1 --target $(TARGET) --lib --release $(OFFLINE_OPTION)
 	@AFTER_CARGO_BUILD@
 
-C_clean:
-	rm -Rf $(SHLIB) $(OBJECTS) ./rust/.cargo $(STATLIB)
+C_cleanup:
+	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo
 
-clean:
+cleanup:
 	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
 
-.PHONY: all C_clean clean
+.PHONY: all C_cleanup cleanup

--- a/src/Makevars.win.in
+++ b/src/Makevars.win.in
@@ -30,9 +30,9 @@ $(STATLIB):
 	@AFTER_CARGO_BUILD@
 
 C_cleanup:
-	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo
+	rm -Rf $(STATLIB) ./rust/.cargo
 
 cleanup:
-	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
+	rm -Rf $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
 
 .PHONY: all C_cleanup cleanup


### PR DESCRIPTION
Address https://github.com/yutannihilation/savvy/issues/355

This pull request removes the intermediate static lib to avoid the new check on the compiled code in the sub-directories. This fix is mainly inspired by [the prior work by hellorust](https://github.com/r-rust/hellorust/commit/9a3ab01fd7ce6b3e5ee24d5af5e8ca3b28abd71f); in short, previously, the intermediate artifacts were supposed to be removed by `make clean`.

```makefile
clean:
	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/
```

However, this is a bit too late because `make clean` happens after the check on the compiled code. So, instead, place `cleanup` (or whatever name of a step other than `clean`) as a dependency of `all` after `$(SHLIB)`. Note that `$(SHLIB)` and `$(OBJECTS)` are removed by `clean` (default).

```makefile
all: $(SHLIB) cleanup

cleanup:
	rm -Rf $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
```