### PR TITLE
Bump MSRV

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
   
-      - uses: dtolnay/rust-toolchain@1.70.0
+      - uses: dtolnay/rust-toolchain@1.78.0
       
       - name: Build
         run: cargo build --manifest-path=./src/rust/Cargo.toml

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,4 +30,4 @@ RoxygenNote: 7.3.2
 SystemRequirements: Cargo (Rust's package manager), rustc
 Biarch: true
 Config/testthat/edition: 3
-Config/string2path/MSRV: 1.70.0
+Config/string2path/MSRV: 1.78.0

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -3,14 +3,7 @@ name = "string2path"
 version = "0.2.0"
 edition = "2021"
 
-rust-version = "1.70"
-
-# TODO:
-# Without specifying this, Cargo.lock's version is set to 4, which requires 
-# Rust 1.78. But, resolve = "3" cannot be understood by Cargo with Rust 1.70.
-# So, uncomment this when executing `cargo update`...
-#
-# resolver = "3"
+rust-version = "1.78"
 
 [lib]
 crate-type = ["staticlib", "lib"]


### PR DESCRIPTION
1.78 should be safe now.

https://github.com/eitsupi/cran-rust-version/releases/tag/2025-03-17