### PR TITLE
Simplify the clean up of intermediate static lib

### DIFF
--- a/configure
+++ b/configure
@@ -36,9 +36,7 @@ elif [ "${NOT_CRAN}" != "true" ]; then
   AFTER_CARGO_BUILD="${AFTER_CARGO_BUILD}"'rm -Rf $(PWD)/.cargo $(LIBDIR)/build'
   VENDORING="yes"
   OFFLINE_OPTION="--offline"
-  CLEANUP="C_cleanup"
 else
-  CLEANUP="cleanup"
   echo "*** Detected NOT_CRAN=true, do not override CARGO_HOME"
 fi
 
@@ -48,7 +46,6 @@ sed \
   -e "s|@VENDORING@|${VENDORING}|" \
   -e "s|@OFFLINE_OPTION@|${OFFLINE_OPTION}|" \
   -e "s|@TARGET@|${TARGET}|" \
-  -e "s|@CLEANUP@|${CLEANUP}|" \
   src/Makevars.in > src/Makevars
 
 # Uncomment this to debug

--- a/configure.win
+++ b/configure.win
@@ -27,9 +27,7 @@ if [ "${NOT_CRAN}" != "true" ]; then
   AFTER_CARGO_BUILD="${AFTER_CARGO_BUILD}"'rm -Rf $(PWD)/.cargo $(LIBDIR)/build'
   VENDORING="yes"
   OFFLINE_OPTION="--offline"
-  CLEANUP="C_cleanup"
 else
-  CLEANUP="cleanup"
   echo "*** Detected NOT_CRAN=true, do not override CARGO_HOME"
 fi
 
@@ -38,7 +36,6 @@ sed \
   -e "s|@AFTER_CARGO_BUILD@|${AFTER_CARGO_BUILD}|" \
   -e "s|@VENDORING@|${VENDORING}|" \
   -e "s|@OFFLINE_OPTION@|${OFFLINE_OPTION}|" \
-  -e "s|@CLEANUP@|${CLEANUP}|" \
   src/Makevars.win.in > src/Makevars.win
 
 # Uncomment this to debug

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -7,7 +7,7 @@ LIBDIR = ./rust/target/$(TARGET)/release
 PKG_LIBS = -L$(LIBDIR) -lstring2path
 STATLIB = $(LIBDIR)/libstring2path.a
 
-all: $(SHLIB) @CLEANUP@
+all: $(SHLIB) clean_intermediate
 
 $(SHLIB): $(STATLIB)
 
@@ -30,10 +30,10 @@ $(STATLIB):
 	fi
 	@AFTER_CARGO_BUILD@
 
-C_cleanup:
+clean_intermediate:
 	rm -Rf $(STATLIB) ./rust/.cargo
 
-cleanup:
-	rm -Rf $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
+clean:
+	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
 
-.PHONY: all C_cleanup cleanup
+.PHONY: all clean_intermediate clean

--- a/src/Makevars.win.in
+++ b/src/Makevars.win.in
@@ -11,7 +11,7 @@ LIBDIR = ./rust/target/$(TARGET)/release
 PKG_LIBS = -L$(LIBDIR) -lstring2path -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
 STATLIB = $(LIBDIR)/libstring2path.a
 
-all: $(SHLIB) @CLEANUP@
+all: $(SHLIB) clean_intermediate
 
 $(SHLIB): $(STATLIB)
 
@@ -29,10 +29,10 @@ $(STATLIB):
 	@BEFORE_CARGO_BUILD@ cd ./rust && cargo build --jobs 1 --target $(TARGET) --lib --release $(OFFLINE_OPTION)
 	@AFTER_CARGO_BUILD@
 
-C_cleanup:
+clean_intermediate:
 	rm -Rf $(STATLIB) ./rust/.cargo
 
-cleanup:
-	rm -Rf $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
+clean:
+	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
 
-.PHONY: all C_cleanup cleanup
+.PHONY: all clean_intermediate clean


### PR DESCRIPTION
A followup of https://github.com/yutannihilation/string2path/pull/144

I mistakenly inserted this long logic (should be opposite), but it still works. So, maybe this is enough...?

```sh
if [ "${NOT_CRAN}" != "true" ]; then
  CLEANUP="C_cleanup"
else
  CLEANUP="cleanup"
fi
```