### PR TITLE
Make sure clean_intermediate is executed after "$(SHLIB)" is created

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -30,7 +30,7 @@ $(STATLIB):
 	fi
 	@AFTER_CARGO_BUILD@
 
-clean_intermediate:
+clean_intermediate: $(SHLIB)
 	rm -Rf $(STATLIB) ./rust/.cargo
 
 clean:

--- a/src/Makevars.win.in
+++ b/src/Makevars.win.in
@@ -29,7 +29,7 @@ $(STATLIB):
 	@BEFORE_CARGO_BUILD@ cd ./rust && cargo build --jobs 1 --target $(TARGET) --lib --release $(OFFLINE_OPTION)
 	@AFTER_CARGO_BUILD@
 
-clean_intermediate:
+clean_intermediate: $(SHLIB)
 	rm -Rf $(STATLIB) ./rust/.cargo
 
 clean:


### PR DESCRIPTION
A followup of #144

I naively assumed this will make the execution order to that `$(SHLIB)` first and then `clean_intermediate`. However, in case `make` is executed in parallel, it's not guaranteed.

```makefile
all: $(SHLIB) clean_intermediate
```

This pull request introduces a dependency between `clean_intermediate` and `$(SHLIB)` so that `clean_intermediate` always happens after building `$(STATLIB)` and `$(SHLIB)`.