### PR TITLE
Support COLR emoji (again)

### DIFF
--- a/src/rust/src/builder.rs
+++ b/src/rust/src/builder.rs
@@ -18,6 +18,27 @@ pub struct RgbaColor {
     pub alpha: u8,
 }
 
+impl std::fmt::Display for RgbaColor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            red,
+            green,
+            blue,
+            alpha,
+        } = self;
+        write!(f, "#{red:02x}{green:02x}{blue:02x}{alpha:02x}")
+    }
+}
+
+/// Formats an optional COLR color as a hex string.
+/// Non-COLR glyphs in mixed text default to opaque black.
+pub fn color_to_hex(color: Option<RgbaColor>) -> String {
+    match color {
+        Some(c) => c.to_string(),
+        None => "#000000ff".to_string(),
+    }
+}
+
 pub trait BuildPath: Build<PathType = Path> + PathBuilder {
     // TODO: lyon::path::builder::Transformed is a struct, not a trait. So, this
     // method is needed to forward the operation.
@@ -27,13 +48,13 @@ pub trait BuildPath: Build<PathType = Path> + PathBuilder {
 
 pub struct LyonPathBuilder<T: BuildPath> {
     pub builders: Vec<T>,
-    pub layer_color: Vec<Option<RgbaColor>>,
     pub cur_layer: usize,
 
     pub cur_glyph_id: u32,
 
     // Completed per-glyph paths produced by `finish_glyph()`.
-    pub glyph_paths: Vec<(u32, Path)>,
+    // Each entry holds (glyph_id, path, optional COLR color).
+    pub glyph_paths: Vec<(u32, Path, Option<RgbaColor>)>,
 
     // This transformation is of COLR format.
     base_transform: lyon::geom::euclid::Transform2D<f32, UnknownUnit, UnknownUnit>,
@@ -54,7 +75,6 @@ impl<T: BuildPath> LyonPathBuilder<T> {
     fn new_inner(builder: T, tolerance: f32, line_width: f32) -> Self {
         Self {
             builders: vec![builder],
-            layer_color: Vec::new(),
             cur_layer: 0,
             cur_glyph_id: 0,
             glyph_paths: Vec::new(),
@@ -75,14 +95,18 @@ impl<T: BuildPath> LyonPathBuilder<T> {
     /// Finalize the current builder's path and store it with the current
     /// glyph ID. Called after each `glyph.draw()` in `draw_glyphs`.
     pub fn finish_glyph(&mut self) {
+        self.finish_glyph_with_color(None);
+    }
+
+    /// Finalize the current builder's path and store it with a COLR color.
+    pub fn finish_glyph_with_color(&mut self, color: Option<RgbaColor>) {
         let old = std::mem::replace(
             &mut self.builders[self.cur_layer],
             T::new_builder(self.tolerance),
         );
         let path = old.build();
-        // Only store non-empty paths (whitespace glyphs produce nothing).
         if path.iter().next().is_some() {
-            self.glyph_paths.push((self.cur_glyph_id, path));
+            self.glyph_paths.push((self.cur_glyph_id, path, color));
         }
         self.update_transform();
     }

--- a/src/rust/src/font.rs
+++ b/src/rust/src/font.rs
@@ -1,13 +1,15 @@
 use std::sync::Mutex;
 
-use crate::builder::{BuildPath, LyonPathBuilder};
+use crate::builder::{BuildPath, LyonPathBuilder, RgbaColor};
 
 use once_cell::sync::Lazy;
+use skrifa::color::{Brush, ColorPainter, CompositeMode};
 use skrifa::instance::Location;
 use skrifa::outline::DrawSettings;
 use skrifa::prelude::{LocationRef, Size, Tag};
 use skrifa::raw::TableProvider;
 use skrifa::raw::tables::kern::SubtableKind;
+use skrifa::raw::types::BoundingBox;
 use skrifa::{FontRef, GlyphId, MetadataProvider};
 
 pub(crate) static FONT_COLLECTION: Lazy<Mutex<fontique::Collection>> = Lazy::new(|| {
@@ -216,8 +218,26 @@ impl<T: BuildPath> LyonPathBuilder<T> {
         let line_height = height + metrics.leading as f32;
 
         let outlines = font.outline_glyphs();
+        let color_glyphs = font.color_glyphs();
         let charmap = font.charmap();
         let glyph_metrics = font.glyph_metrics(Size::unscaled(), location);
+
+        // Extract the default CPAL palette for COLR color glyphs.
+        let palette: Vec<RgbaColor> = font
+            .color_palettes()
+            .get(0)
+            .map(|p| {
+                p.colors()
+                    .iter()
+                    .map(|c| RgbaColor {
+                        red: c.red,
+                        green: c.green,
+                        blue: c.blue,
+                        alpha: c.alpha,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
 
         let mut prev_glyph: Option<GlyphId> = None;
         for c in text.chars() {
@@ -242,9 +262,19 @@ impl<T: BuildPath> LyonPathBuilder<T> {
             }
 
             if !c.is_whitespace() {
-                // TODO: Implement COLR color glyph support via skrifa::color::ColorPainter.
-                // Currently falling back to regular outline rendering only.
-                if let Some(glyph) = outlines.get(cur_glyph) {
+                if let Some(color_glyph) = color_glyphs.get(cur_glyph) {
+                    // COLR color glyph: paint produces one finish_glyph_with_color
+                    // call per layer via the ColrPainter callbacks.
+                    let mut painter = ColrPainter {
+                        builder: self,
+                        outlines: &outlines,
+                        location,
+                        palette: &palette,
+                    };
+                    color_glyph
+                        .paint(location, &mut painter)
+                        .map_err(|e| savvy::Error::new(format!("{e:?}")))?;
+                } else if let Some(glyph) = outlines.get(cur_glyph) {
                     glyph
                         .draw(DrawSettings::unhinted(Size::unscaled(), location), self)
                         .map_err(|e| savvy::Error::new(e.to_string()))?;
@@ -285,4 +315,75 @@ fn find_kerning(font: &FontRef<'_>, left: GlyphId, right: GlyphId) -> f32 {
         }
     }
     0.0
+}
+
+/// Implements skrifa's [`ColorPainter`] to render COLR color glyphs.
+///
+/// For each layer the COLR traversal visits, the outline is drawn into the
+/// builder and finalized with the layer's palette color.  This supports both
+/// COLRv0 (via the `fill_glyph` fast-path) and basic COLRv1 (via the
+/// `push_clip_glyph` + `fill` sequence).
+struct ColrPainter<'a, 'f, T: BuildPath> {
+    builder: &'a mut LyonPathBuilder<T>,
+    outlines: &'a skrifa::outline::OutlineGlyphCollection<'f>,
+    location: LocationRef<'a>,
+    palette: &'a [RgbaColor],
+}
+
+impl<T: BuildPath> ColrPainter<'_, '_, T> {
+    fn resolve_color(&self, brush: &Brush<'_>) -> Option<RgbaColor> {
+        match brush {
+            Brush::Solid {
+                palette_index,
+                alpha,
+            } => self
+                .palette
+                .get(*palette_index as usize)
+                .map(|&c| RgbaColor {
+                    alpha: (c.alpha as f32 * alpha) as u8,
+                    ..c
+                }),
+            _ => None,
+        }
+    }
+
+    fn draw_outline(&mut self, glyph_id: GlyphId) {
+        if let Some(glyph) = self.outlines.get(glyph_id) {
+            let _ = glyph.draw(
+                DrawSettings::unhinted(Size::unscaled(), self.location),
+                self.builder,
+            );
+        }
+    }
+}
+
+impl<T: BuildPath> ColorPainter for ColrPainter<'_, '_, T> {
+    fn push_transform(&mut self, _transform: skrifa::color::Transform) {}
+    fn pop_transform(&mut self) {}
+
+    fn push_clip_glyph(&mut self, glyph_id: GlyphId) {
+        self.draw_outline(glyph_id);
+    }
+
+    fn push_clip_box(&mut self, _clip_box: BoundingBox<f32>) {}
+    fn pop_clip(&mut self) {}
+
+    fn fill(&mut self, brush: Brush<'_>) {
+        let color = self.resolve_color(&brush);
+        self.builder.finish_glyph_with_color(color);
+    }
+
+    fn push_layer(&mut self, _composite_mode: CompositeMode) {}
+
+    /// Fast-path for COLRv0: each layer is a single glyph with a solid color.
+    fn fill_glyph(
+        &mut self,
+        glyph_id: GlyphId,
+        _brush_transform: Option<skrifa::color::Transform>,
+        brush: Brush<'_>,
+    ) {
+        let color = self.resolve_color(&brush);
+        self.draw_outline(glyph_id);
+        self.builder.finish_glyph_with_color(color);
+    }
 }

--- a/src/rust/src/into_fill_stroke.rs
+++ b/src/rust/src/into_fill_stroke.rs
@@ -1,12 +1,13 @@
-use crate::{builder::LyonPathBuilderForStrokeAndFill, result::PathTibble};
+use crate::{
+    builder::{LyonPathBuilderForStrokeAndFill, RgbaColor, color_to_hex},
+    result::PathTibble,
+};
 
 use lyon::tessellation::*;
 
 #[derive(Copy, Clone, Debug)]
 struct Vertex(lyon::math::Point);
 
-// This can have some members so that it can be used in new_vertex(), but I
-// don't find any useful usage yet.
 struct VertexCtor {}
 
 impl FillVertexConstructor<Vertex> for VertexCtor {
@@ -24,19 +25,20 @@ impl StrokeVertexConstructor<Vertex> for VertexCtor {
 impl LyonPathBuilderForStrokeAndFill {
     /// Convert the outline paths into fill as triangles.
     pub fn into_fill(self) -> PathTibble {
+        let has_color = self.glyph_paths.iter().any(|(_, _, c)| c.is_some());
         let mut result = PathTibble {
             x: Vec::new(),
             y: Vec::new(),
             glyph_id: Vec::new(),
             path_id: None,
             triangle_id: Some(Vec::new()),
-            color: None,
+            color: if has_color { Some(Vec::new()) } else { None },
         };
 
         let mut tessellator = FillTessellator::new();
         let options = FillOptions::tolerance(self.tolerance).with_fill_rule(FillRule::NonZero);
 
-        for (glyph_id, glyph_path) in &self.glyph_paths {
+        for (glyph_id, glyph_path, color) in &self.glyph_paths {
             let mut geometry: VertexBuffers<Vertex, usize> = VertexBuffers::new();
             tessellator
                 .tessellate_path(
@@ -45,26 +47,27 @@ impl LyonPathBuilderForStrokeAndFill {
                     &mut BuffersBuilder::new(&mut geometry, VertexCtor {}),
                 )
                 .unwrap();
-            extract_vertex_buffer(geometry, &mut result, *glyph_id as i32);
+            extract_vertex_buffer(geometry, &mut result, *glyph_id as i32, *color);
         }
         result
     }
 
     /// Convert the outline paths into stroke with a specified line width as triangles.
     pub fn into_stroke(self) -> PathTibble {
+        let has_color = self.glyph_paths.iter().any(|(_, _, c)| c.is_some());
         let mut result = PathTibble {
             x: Vec::new(),
             y: Vec::new(),
             glyph_id: Vec::new(),
             path_id: None,
             triangle_id: Some(Vec::new()),
-            color: None,
+            color: if has_color { Some(Vec::new()) } else { None },
         };
 
         let mut tessellator = StrokeTessellator::new();
         let options = StrokeOptions::tolerance(self.tolerance).with_line_width(self.line_width);
 
-        for (glyph_id, glyph_path) in &self.glyph_paths {
+        for (glyph_id, glyph_path, color) in &self.glyph_paths {
             let mut geometry: VertexBuffers<Vertex, usize> = VertexBuffers::new();
             tessellator
                 .tessellate_path(
@@ -73,7 +76,7 @@ impl LyonPathBuilderForStrokeAndFill {
                     &mut BuffersBuilder::new(&mut geometry, VertexCtor {}),
                 )
                 .unwrap();
-            extract_vertex_buffer(geometry, &mut result, *glyph_id as i32);
+            extract_vertex_buffer(geometry, &mut result, *glyph_id as i32, *color);
         }
         result
     }
@@ -83,11 +86,13 @@ fn extract_vertex_buffer(
     geometry: VertexBuffers<Vertex, usize>,
     dst: &mut PathTibble,
     glyph_id: i32,
+    paint_color: Option<RgbaColor>,
 ) {
     let offset = dst.triangle_id.as_ref().map_or(0, |v| match v.last() {
         Some(last_triangle_id) => last_triangle_id + 1,
         None => 0,
     });
+    let color_str = dst.color.as_ref().map(|_| color_to_hex(paint_color));
     for (n, &i) in geometry.indices.iter().enumerate() {
         if let Some(v) = geometry.vertices.get(i) {
             dst.x.push(v.0.x as _);
@@ -95,6 +100,9 @@ fn extract_vertex_buffer(
             dst.glyph_id.push(glyph_id);
             if let Some(triangle_id) = &mut dst.triangle_id {
                 triangle_id.push(n as i32 / 3 + offset);
+            }
+            if let Some(color) = &mut dst.color {
+                color.push(color_str.as_ref().unwrap().clone());
             }
         }
     }

--- a/src/rust/src/into_path.rs
+++ b/src/rust/src/into_path.rs
@@ -1,19 +1,21 @@
 use i_overlay::core::fill_rule::FillRule;
 use i_overlay::float::simplify::SimplifyShape;
 
-use crate::builder::LyonPathBuilderForPath;
+use crate::builder::{LyonPathBuilderForPath, color_to_hex};
 use crate::result::PathTibble;
 
 impl LyonPathBuilderForPath {
     pub fn into_path(self) -> PathTibble {
+        let has_color = self.glyph_paths.iter().any(|(_, _, c)| c.is_some());
+
         let mut x = Vec::new();
         let mut y = Vec::new();
         let mut glyph_id = Vec::new();
         let mut path_id = Vec::new();
+        let mut color_vec: Vec<String> = Vec::new();
         let mut out_path_id: u32 = 0;
 
-        for (gid, glyph_path) in &self.glyph_paths {
-            // Collect contours from the flattened path for this glyph.
+        for (gid, glyph_path, paint_color) in &self.glyph_paths {
             let mut contours: Vec<Vec<[f32; 2]>> = Vec::new();
             let mut cur_contour: Vec<[f32; 2]> = Vec::new();
 
@@ -49,6 +51,12 @@ impl LyonPathBuilderForPath {
             // of a composite glyph) while preserving counter-shapes (holes).
             let merged = contours.simplify_shape(FillRule::NonZero);
 
+            let color_str = if has_color {
+                Some(color_to_hex(*paint_color))
+            } else {
+                None
+            };
+
             for shape in merged {
                 for contour in shape {
                     if contour.is_empty() {
@@ -56,6 +64,7 @@ impl LyonPathBuilderForPath {
                     }
                     out_path_id += 1;
                     let first = contour[0];
+                    let n_points = contour.len() + 1; // contour points + closing point
                     for pt in &contour {
                         x.push(pt[0] as f64);
                         y.push(pt[1] as f64);
@@ -69,6 +78,10 @@ impl LyonPathBuilderForPath {
                     y.push(first[1] as f64);
                     glyph_id.push(*gid as i32);
                     path_id.push(out_path_id as i32);
+
+                    if let Some(s) = &color_str {
+                        color_vec.extend(std::iter::repeat_n(s.clone(), n_points));
+                    }
                 }
             }
         }
@@ -79,7 +92,7 @@ impl LyonPathBuilderForPath {
             glyph_id,
             path_id: Some(path_id),
             triangle_id: None,
-            color: None,
+            color: if has_color { Some(color_vec) } else { None },
         }
     }
 }


### PR DESCRIPTION
- Restore COLR color emoji support lost during the fontique+skrifa migration (#194)
- Implement skrifa's ColorPainter trait via a ColrPainter struct, supporting COLRv0 (layered solid-color glyphs) and basic COLRv1 (clip + fill)
- Extract the default CPAL palette and resolve each layer's color, storing it alongside the glyph path
- Propagate the color column to string2path(), string2fill(), and string2stroke() output; non-color fonts are unaffected (no color column emitted)

``` r
library(string2path)
library(ggplot2)

ttf <- "~/../Downloads/Noto_Color_Emoji/NotoColorEmoji-Regular.ttf"
d <-
  string2fill("🌶", ttf, tolerance = 1e-4) |>
  tibble::rowid_to_column()

ggplot(d) +
  geom_polygon(aes(x, y, group = triangle_id, fill = color), colour = "transparent") +
  coord_equal() +
  theme_minimal() +
  theme(legend.position = "none") +
  scale_fill_identity()
```

![](https://i.imgur.com/tgc5Efk.png)<!-- -->

<sup>Created on 2026-04-11 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
