### PR TITLE
Always override CC and CFLAGS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # string2path 0.3.0
 
+* Fix a CRAN warning about macOS deployment target mismatch on M1.
+
 * Migrate to fontique and skrifa (#99).
   * Support variable fonts.
   * Drop support for WASM for now.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,1 +1,5 @@
-This release overhauls the internals, but contains no user-facing breaking changes.
+This is a resubmission. The previous submission had a linker warning on
+M1 macOS about an object file built for a newer macOS version than being
+linked. This was because the C compiler flags (including
+`-mmacos-version-min`) were not passed through to a C file compiled
+during the Rust build. This should be now fixed.

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -20,11 +20,11 @@ $(STATLIB):
 	    cp ./cargo_vendor_config.toml ./rust/.cargo/config.toml; \
 	fi
 
+	export CC="$(CC)" && \
+	export CFLAGS="$(CFLAGS)" && \
 	if [ "$(TARGET)" != "wasm32-unknown-emscripten" ]; then \
 	  @BEFORE_CARGO_BUILD@ cd ./rust && cargo build --jobs 1 --lib --release $(OFFLINE_OPTION); \
 	else \
-	  export CC="$(CC)" && \
-	  export CFLAGS="$(CFLAGS)" && \
 	  export CARGO_PROFILE_RELEASE_PANIC="abort" && \
 	  export RUSTFLAGS="$(RUSTFLAGS) -Zdefault-visibility=hidden" && \
 	  @BEFORE_CARGO_BUILD@ cd ./rust && cargo +nightly build --lib --release --target $(TARGET) -Zbuild-std=panic_abort,std $(OFFLINE_OPTION); \


### PR DESCRIPTION
I need to address this.

> Thanks, we see no change on M1Mac:
> 
> Found the following significant warnings:
>    ld: warning: object file
(/private/tmp/string2path.Rcheck/00_pkg_src/string2path/src/rust/target/release/libstring2path.a[175](ea708c7824d36062-unwind_protect_wrapper.o))
> was built for newer 'macOS' version (26.5) than being linked (26.0)
> See ‘/private/tmp/string2path.Rcheck/00install.out’ for details.
> 
> 
> Please fix and resubmit.