### PR TITLE
Fix error on intel macOS

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -18,6 +18,7 @@ jobs:
         config:
           - {os: windows-latest, r: 'release',  rust: 'stable-msvc'}
           - {os: macOS-latest,   r: 'release',  rust: 'stable'     }
+          - {os: macos-15-intel, r: 'release',  rust: 'stable'     }
           - {os: ubuntu-latest,  r: 'release',  rust: 'stable'     }
           - {os: ubuntu-latest,  r: 'devel',    rust: 'stable'     }
           - {os: ubuntu-latest,  r: 'release',  rust: 'nightly'    }

--- a/configure
+++ b/configure
@@ -70,6 +70,14 @@ if [ "$(uname)" = "Darwin" ]; then
   MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
   echo "using macOS deployment target: ${MACOSX_DEPLOYMENT_TARGET}"
   BEFORE_CARGO_BUILD="${BEFORE_CARGO_BUILD}"' export MACOSX_DEPLOYMENT_TARGET="'"${MACOSX_DEPLOYMENT_TARGET}"'" \&\&'
+
+  # Link Apple frameworks used transitively by the font-kit / core-text Rust
+  # crates. The `#[link(..., kind = "framework")]` attributes inside those
+  # crates are dropped when the crate is consumed as a staticlib, so the
+  # final R link step must request the frameworks explicitly. Otherwise
+  # symbols like `_kCTFontURLAttribute` end up unresolved in the flat
+  # namespace and fail at dyld load time (notably on x86_64 macOS builders).
+  ADDITIONAL_PKG_LIBS="${ADDITIONAL_PKG_LIBS} -framework Foundation -framework CoreText -framework CoreFoundation -framework CoreGraphics -framework AppKit"
 fi
 
 sed \


### PR DESCRIPTION
```
checking dependencies in R code ... NOTE
Error: unable to load shared object '/Volumes/Builds/packages/big-sur-x86_64/results/4.5/string2path.Rcheck/string2path/libs/string2path.so':
  dlopen(/Volumes/Builds/packages/big-sur-x86_64/results/4.5/string2path.Rcheck/string2path/libs/string2path.so, 0x0006): symbol not found in flat namespace '_kCTFontURLAttribute'
Call sequence:
3: dyn.load(file, DLLpath = DLLpath, ...)
2: library.dynam(lib, package, package.lib)
1: loadNamespace(package, lib.loc)
Execution halted
```