### PR TITLE
Ignore -flto=* CFLAGS

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -21,7 +21,7 @@ $(STATLIB):
 	fi
 
 	export CC="$(CC)" && \
-	export CFLAGS="$(CFLAGS)" && \
+	export CFLAGS="$(CFLAGS) -flto=10" && \
 	if [ "$(TARGET)" != "wasm32-unknown-emscripten" ]; then \
 	  @BEFORE_CARGO_BUILD@ cd ./rust && cargo build --jobs 1 --lib --release $(OFFLINE_OPTION); \
 	else \

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -26,7 +26,7 @@ $(STATLIB):
 # plain `ar`, which doesn't record GCC LTO symbols, leaving
 # unwind_protect_impl undefined at dyn.load time.
 	export CC="$(CC)" && \
-	export CFLAGS="$(CFLAGS) -flto=10 -fno-lto" && \
+	export CFLAGS="$(CFLAGS) -fno-lto" && \
 	if [ "$(TARGET)" != "wasm32-unknown-emscripten" ]; then \
 	  @BEFORE_CARGO_BUILD@ cd ./rust && cargo build --jobs 1 --lib --release $(OFFLINE_OPTION); \
 	else \

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -21,7 +21,7 @@ $(STATLIB):
 	fi
 
 	export CC="$(CC)" && \
-	export CFLAGS="$(CFLAGS) -flto=10" && \
+	export CFLAGS="$(CFLAGS)" && \
 	if [ "$(TARGET)" != "wasm32-unknown-emscripten" ]; then \
 	  @BEFORE_CARGO_BUILD@ cd ./rust && cargo build --jobs 1 --lib --release $(OFFLINE_OPTION); \
 	else \

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -20,8 +20,13 @@ $(STATLIB):
 	    cp ./cargo_vendor_config.toml ./rust/.cargo/config.toml; \
 	fi
 
+# Note: -fno-lto is appended to CFLAGS to override any -flto* injected by R
+# (e.g. the gcc-SAN builder uses -flto=10). The cc crate compiles savvy's
+# unwind_protect_wrapper.c with these CFLAGS and archives the result with
+# plain `ar`, which doesn't record GCC LTO symbols, leaving
+# unwind_protect_impl undefined at dyn.load time.
 	export CC="$(CC)" && \
-	export CFLAGS="$(CFLAGS)" && \
+	export CFLAGS="$(CFLAGS) -flto=10 -fno-lto" && \
 	if [ "$(TARGET)" != "wasm32-unknown-emscripten" ]; then \
 	  @BEFORE_CARGO_BUILD@ cd ./rust && cargo build --jobs 1 --lib --release $(OFFLINE_OPTION); \
 	else \


### PR DESCRIPTION
[gcc-ASAN build](https://www.stats.ox.ac.uk/pub/bdr/memtests/gcc-ASAN/string2path/00install.out) is failing. It seems this is because gcc-ASAN build adds `-flto=10`; since the latest Makevars.in passes CFLAGS to the cc crate, it blows away the symbol. We should not let it get optimized at this point.

```
** testing if installed package can be loaded from temporary location
Error: package or namespace load failed for ‘string2path’ in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/data/gannet/ripley/R/packages/tests-gcc-SAN/string2path.Rcheck/00LOCK-string2path/00new/string2path/libs/string2path.so':
  /data/gannet/ripley/R/packages/tests-gcc-SAN/string2path.Rcheck/00LOCK-string2path/00new/string2path/libs/string2path.so: undefined symbol: unwind_protect_impl
Error: loading failed
Execution halted
ERROR: loading failed
```